### PR TITLE
[report problem] undedupe yarn 3 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # yarn-berry-deduplicate
 
 _This is a fork of [yarn-deduplicate](https://www.npmjs.com/package/yarn-deduplicate) for yarn
-berry. _
+berry._
 
 Cleans up `yarn.lock` by removing duplicates.
 


### PR DESCRIPTION
Hey,

> As this is a fork, I unfortunately cannot open an issue. So using a fake PR for it.

Thanks a lot for this - it helps us a lot on the large repo [jupyterlab](https://github.com/jupyterlab/jupyterlab).

When running this tool, there seems to be one dependency specification that get considered as different version although yarn v3 is actually deduping them. This is an example of undeduplication that this script is applying on the jupyterlab yarn.lock:

![image](https://github.com/christophehurpeau/yarn-deduplicate/assets/8435071/1514dae3-e134-4ae0-8294-48971a186d8d)

It happens for another package `"string-width-cjs@npm:string-width@^4.2.0"`. So it seems that that specification of version is not correctly handle.

Could we help fix this as it renders the `--fail` option useless in our CI job?